### PR TITLE
Protect email against spambots

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: Hypha Worker Co-operative
 email: hello [at] hypha [dot] coop
-email-hidden: %68%65%6c%6c%6f%40%68%79%70%68%61%2e%63%6f%6f%70
+email-hidden: "%68%65%6c%6c%6f%40%68%79%70%68%61%2e%63%6f%6f%70"
 phone: +1 437-887-6936
 address: Toronto, ON
 github: https://github.com/hyphacoop

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 title: Hypha Worker Co-operative
-email: hello@hypha.coop
+email: hello [at] hypha [dot] coop
+email-hidden: %68%65%6c%6c%6f%40%68%79%70%68%61%2e%63%6f%6f%70
 phone: +1 437-887-6936
 address: Toronto, ON
 github: https://github.com/hyphacoop

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
               Stay tuned for updates!</p>
             <div id="contact" class="smaller">
               <span id="phone"><i class="fas fa-phone mr-1"></i> <a href="tel:{{ site.phone}}">{{ site.phone }}</a></span><br />
-              <span id="email"><i class="fas fa-envelope mr-1"></i> <a href="mailto:{{ site.email }}">{{ site.email }}</a></span><br />
+              <span id="email"><i class="fas fa-envelope mr-1"></i> <a href="mailto:{{ site.email-hidden }}">{{ site.email }}</a></span><br />
               <span id="address"><i class="fas fa-globe-americas mr-1"></i> {{ site.address }}</span>
             </div>
             {% if site.show_form %}


### PR DESCRIPTION
Thoughts? :+1:  or :-1: 

Issue: Clear emails on sites attract spam bots

`%68%65%6c%6c%6f%40%68%79%70%68%61%2e%63%6f%6f%70` is URL encoded version of `hello@hypha.coop` for use with "mailto:" href

`hello [at] hypha [dot] coop` is human readable but confuses bots

Its not perfect, but it curbs the less sophisticated regex bots out there.

